### PR TITLE
esp32: Use forward slashes in include paths

### DIFF
--- a/esp32/PrimaryESP32/alphabot/alphabot.ino
+++ b/esp32/PrimaryESP32/alphabot/alphabot.ino
@@ -5,8 +5,8 @@
 #include "BLEHandler.h"
 #include "config.h"
 #include <esp32-hal-cpu.h>
-#include <soc\soc.h>
-#include <soc\rtc_cntl_reg.h>
+#include <soc/soc.h>
+#include <soc/rtc_cntl_reg.h>
 #include "PositioningSystem.h"
 #include <math.h>
 #include "Compass.h"

--- a/esp32/SecondaryESP32/alphabot_secondary_esp32/alphabot_secondary_esp32.ino
+++ b/esp32/SecondaryESP32/alphabot_secondary_esp32/alphabot_secondary_esp32.ino
@@ -5,9 +5,9 @@
 #include <esp_wifi.h>
 #include <esp_bt.h>
 #include <esp32-hal-cpu.h>
-#include <driver\adc.h>
-#include <soc\soc.h>
-#include <soc\rtc_cntl_reg.h>
+#include <driver/adc.h>
+#include <soc/soc.h>
+#include <soc/rtc_cntl_reg.h>
 
 //#define DEBUG
 


### PR DESCRIPTION
Always use forward slahes in the path when including header files,
otherwise builds fail on Linux.