### PR TITLE
esp32/PrimaryESP32: Fix compiler warnings

### DIFF
--- a/esp32/PrimaryESP32/alphabot/DistanceMeter.cpp
+++ b/esp32/PrimaryESP32/alphabot/DistanceMeter.cpp
@@ -8,7 +8,7 @@ void DistanceMeter::readValues(uint16_t* front, uint16_t* left, uint16_t* right,
     if (err)
         return;
 
-    uint8_t size = Wire.requestFrom(this->address, 9);
+    uint8_t size = Wire.requestFrom(this->address, 9U);
 
     if (size < 9)
         return;

--- a/esp32/PrimaryESP32/lib/Mecha_QMC5883L/src/MechaQMC5883.cpp
+++ b/esp32/PrimaryESP32/lib/Mecha_QMC5883L/src/MechaQMC5883.cpp
@@ -39,7 +39,7 @@ void MechaQMC5883::read(int16_t* x,int16_t* y,int16_t* z){
   Wire.beginTransmission(address);
   Wire.write(0x00);
   Wire.endTransmission();
-  Wire.requestFrom(address, 6);
+  Wire.requestFrom(address, 6U);
   *x = Wire.read(); //LSB  x
   *x |= Wire.read() << 8; //MSB  x
   *y = Wire.read(); //LSB  z


### PR DESCRIPTION
Fix compiler warnings by adding a 'U' suffix to unsigned integers.