### PR TITLE
emulator_rpi: Fix colorama color in GitHub Actions

### DIFF
--- a/emulator_rpi.py
+++ b/emulator_rpi.py
@@ -295,7 +295,7 @@ while i < (len(sys.argv) - 1):
 
     i += 1
 
-init()
+init(strip=False)
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 


### PR DESCRIPTION
Fix colorama not displaying color when running the emulator in a GitHub
Actions workflow.

Closes #1