### PR TITLE
esp32/PrimaryESP32: Make some member functions const

### DIFF
--- a/esp32/PrimaryESP32/alphabot/Compass.cpp
+++ b/esp32/PrimaryESP32/alphabot/Compass.cpp
@@ -29,7 +29,7 @@ void Compass::setAngleOffset(float offset) {
     angle_offset = offset;
 }
 
-float Compass::getAngleOffset() {
+float Compass::getAngleOffset() const {
     return angle_offset;
 }
 
@@ -55,19 +55,19 @@ void Compass::beginMagnetSensorCalibration() {
     min_max_set = false;
 }
 
-int16_t Compass::getMinX() {
+int16_t Compass::getMinX() const {
     return min_x;
 }
 
-int16_t Compass::getMaxX() {
+int16_t Compass::getMaxX() const {
     return max_x;
 }
 
-int16_t Compass::getMinY() {
+int16_t Compass::getMinY() const {
     return min_y;
 }
 
-int16_t Compass::getMaxY() {
+int16_t Compass::getMaxY() const {
     return max_y;
 }
 

--- a/esp32/PrimaryESP32/alphabot/Compass.h
+++ b/esp32/PrimaryESP32/alphabot/Compass.h
@@ -19,13 +19,13 @@ public:
     float getRawDirection();
     void setMagnetSensorCalibratedValues(int16_t min_x, int16_t max_x, int16_t min_y, int16_t max_y);
     void setAngleOffset(float offset);
-    float getAngleOffset();
+    float getAngleOffset() const;
     void magnetSensorCalibrate();
     void beginMagnetSensorCalibration();
-    int16_t getMinX();
-    int16_t getMaxX();
-    int16_t getMinY();
-    int16_t getMaxY();
+    int16_t getMinX() const;
+    int16_t getMaxX() const;
+    int16_t getMinY() const;
+    int16_t getMaxY() const;
     float getDirection();
 
     Compass();

--- a/esp32/PrimaryESP32/alphabot/DrivingAssistent.cpp
+++ b/esp32/PrimaryESP32/alphabot/DrivingAssistent.cpp
@@ -75,7 +75,7 @@ void DrivingAssistent::computeNextStep(int8_t* spd, int8_t* steer) {
     *steer = this->steer;
 }
 
-int8_t DrivingAssistent::safeSpeedForward(int8_t speed) {
+int8_t DrivingAssistent::safeSpeedForward(int8_t speed) const {
     float stoppingDistance = (speed * FULL_SPEED_ROLL) / 128.0;
 
     if (min(this->dist_front, min(this->dist_left, this->dist_right)) <= (MIN_DIST_TO_OBSTACLE + stoppingDistance)) {
@@ -93,7 +93,7 @@ int8_t DrivingAssistent::safeSpeedForward(int8_t speed) {
     return speed;
 }
 
-int8_t DrivingAssistent::safeSpeedBackward(int8_t speed) {
+int8_t DrivingAssistent::safeSpeedBackward(int8_t speed) const {
     float stoppingDistance = (-speed * FULL_SPEED_ROLL) / 128.0;
 
     if (this->dist_back <= (MIN_DIST_TO_OBSTACLE + stoppingDistance)) {

--- a/esp32/PrimaryESP32/alphabot/DrivingAssistent.h
+++ b/esp32/PrimaryESP32/alphabot/DrivingAssistent.h
@@ -24,8 +24,8 @@ public:
     void updateDistanceBack(uint16_t back);
     void updateSpeedAndSteer(int8_t spd, int8_t steer);
     void computeNextStep(int8_t* spd, int8_t* steer);
-    int8_t safeSpeedForward(int8_t speed);
-    int8_t safeSpeedBackward(int8_t speed);
+    int8_t safeSpeedForward(int8_t speed) const;
+    int8_t safeSpeedBackward(int8_t speed) const;
 
     DrivingAssistent();
 };

--- a/esp32/PrimaryESP32/alphabot/Navigator.cpp
+++ b/esp32/PrimaryESP32/alphabot/Navigator.cpp
@@ -11,7 +11,7 @@ void Navigator::setTarget(float x, float y) {
     has_target = true;
 }
 
-bool Navigator::hasTarget() {
+bool Navigator::hasTarget() const {
     return has_target;
 }
 

--- a/esp32/PrimaryESP32/alphabot/Navigator.h
+++ b/esp32/PrimaryESP32/alphabot/Navigator.h
@@ -17,7 +17,7 @@ private:
 public:
     void setOwnPosition(float x, float y);
     void setTarget(float x, float y);
-    bool hasTarget();
+    bool hasTarget() const;
     void clearObstacles();
     void addObstacle(float x, float y, float width, float height);
     void navigateStep(float dir, std::list<Coordinate>& path);

--- a/esp32/PrimaryESP32/alphabot/PositioningSystem.cpp
+++ b/esp32/PrimaryESP32/alphabot/PositioningSystem.cpp
@@ -116,27 +116,27 @@ void PositioningSystem::calculatePosition(float anc1_dist, float anc2_dist, floa
     (*y) = anc1_y + ((sq(anc1_dist) - sq(anc3_dist) + sq(i) + sq(j)) / (2 * j)) - ((i / j) * (*x));
 }
 
-float PositioningSystem::getAnc1X() {
+float PositioningSystem::getAnc1X() const {
     return anc1_x;
 }
 
-float PositioningSystem::getAnc1Y() {
+float PositioningSystem::getAnc1Y() const {
     return anc1_y;
 }
 
-float PositioningSystem::getAnc2X() {
+float PositioningSystem::getAnc2X() const {
     return anc2_x;
 }
 
-float PositioningSystem::getAnc2Y() {
+float PositioningSystem::getAnc2Y() const {
     return anc2_y;
 }
 
-float PositioningSystem::getAnc3X() {
+float PositioningSystem::getAnc3X() const {
     return anc3_x;
 }
 
-float PositioningSystem::getAnc3Y() {
+float PositioningSystem::getAnc3Y() const {
     return anc3_y;
 }
 

--- a/esp32/PrimaryESP32/alphabot/PositioningSystem.h
+++ b/esp32/PrimaryESP32/alphabot/PositioningSystem.h
@@ -21,12 +21,12 @@ public:
     void readDistances(float* anc1_dist, float* anc2_dist, float* anc3_dist);
     void setAnchorPositions(float anc1_x, float anc1_y, float anc2_x, float anc2_y, float anc3_x, float anc3_y);
     void calculatePosition(float anc1_dist, float anc2_dist, float anc3_dist, float* x, float* y);
-    float getAnc1X();
-    float getAnc1Y();
-    float getAnc2X();
-    float getAnc2Y();
-    float getAnc3X();
-    float getAnc3Y();
+    float getAnc1X() const;
+    float getAnc1Y() const;
+    float getAnc2X() const;
+    float getAnc2Y() const;
+    float getAnc3X() const;
+    float getAnc3Y() const;
 
     PositioningSystem(uint16_t anc1_short_address, uint16_t anc2_short_address, uint16_t anc3_short_address);
 };

--- a/esp32/PrimaryESP32/alphabot/SaveFile.cpp
+++ b/esp32/PrimaryESP32/alphabot/SaveFile.cpp
@@ -2,23 +2,23 @@
 #include "FS.h"
 #include "SPIFFS.h"
 
-int16_t SaveFile::getMagnetSensorCalibratedMinX() {
+int16_t SaveFile::getMagnetSensorCalibratedMinX() const {
     return magnetSensorCalibratedMinX;
 }
 
-int16_t SaveFile::getMagnetSensorCalibratedMaxX() {
+int16_t SaveFile::getMagnetSensorCalibratedMaxX() const {
     return magnetSensorCalibratedMaxX;
 }
 
-int16_t SaveFile::getMagnetSensorCalibratedMinY() {
+int16_t SaveFile::getMagnetSensorCalibratedMinY() const {
     return magnetSensorCalibratedMinY;
 }
 
-int16_t SaveFile::getMagnetSensorCalibratedMaxY() {
+int16_t SaveFile::getMagnetSensorCalibratedMaxY() const {
     return magnetSensorCalibratedMaxY;
 }
 
-float SaveFile::getCompassAngleOffset() {
+float SaveFile::getCompassAngleOffset() const {
     return compassAngleOffset;
 }
 

--- a/esp32/PrimaryESP32/alphabot/SaveFile.h
+++ b/esp32/PrimaryESP32/alphabot/SaveFile.h
@@ -15,11 +15,11 @@ private:
     void read();
 
 public:
-    int16_t getMagnetSensorCalibratedMinX();
-    int16_t getMagnetSensorCalibratedMaxX();
-    int16_t getMagnetSensorCalibratedMinY();
-    int16_t getMagnetSensorCalibratedMaxY();
-    float getCompassAngleOffset();
+    int16_t getMagnetSensorCalibratedMinX() const;
+    int16_t getMagnetSensorCalibratedMaxX() const;
+    int16_t getMagnetSensorCalibratedMinY() const;
+    int16_t getMagnetSensorCalibratedMaxY() const;
+    float getCompassAngleOffset() const;
     void setMagnetSensorCalibratedMinX(int16_t min_x);
     void setMagnetSensorCalibratedMaxX(int16_t max_x);
     void setMagnetSensorCalibratedMinY(int16_t min_y);

--- a/esp32/PrimaryESP32/alphabot/TwoMotorDrive.cpp
+++ b/esp32/PrimaryESP32/alphabot/TwoMotorDrive.cpp
@@ -68,11 +68,11 @@ void TwoMotorDrive::updateMotors(int8_t x, int8_t y) {
     this->steer_direction = x;
 }
 
-int8_t TwoMotorDrive::getSpeed() {
+int8_t TwoMotorDrive::getSpeed() const {
     return this->speed;
 }
 
-int8_t TwoMotorDrive::getSteerDirection() {
+int8_t TwoMotorDrive::getSteerDirection() const {
     return this->steer_direction;
 }
 

--- a/esp32/PrimaryESP32/alphabot/TwoMotorDrive.h
+++ b/esp32/PrimaryESP32/alphabot/TwoMotorDrive.h
@@ -22,8 +22,8 @@ public:
     void rightBackward();
     void steer(int16_t dir);
     void updateMotors(int8_t x, int8_t y);
-    int8_t getSpeed();
-    int8_t getSteerDirection();
+    int8_t getSpeed() const;
+    int8_t getSteerDirection() const;
 
     TwoMotorDrive(Motor* motor_left, Motor* motor_right, StepperMotor* motor_steer);
 };


### PR DESCRIPTION
Add the const keyword to class member functions that do not modify the
called object.