### PR TITLE
esp32/PrimaryESP32: Expose BLE service

### DIFF
--- a/esp32/PrimaryESP32/alphabot/BLEHandler.cpp
+++ b/esp32/PrimaryESP32/alphabot/BLEHandler.cpp
@@ -173,6 +173,8 @@ BLEHandler::BLEHandler(void (*dataReceived)(BLEUUID, const char*, size_t), void 
     charPathfindingPath->setValue("");
 
     service->start();
+    advertising->addServiceUUID(BLE_SVC_UUID);
+    advertising->setScanResponse(true);
     advertising->start();
     #ifdef DEBUG
     Serial.println("BLE Advertising started");


### PR DESCRIPTION
Advertise the BLE service UUID to improve support with other clients.