### PR TITLE
esp32/PrimaryESP32: Fix inverted speed in Navigator

### DIFF
--- a/esp32/PrimaryESP32/alphabot/Navigator.cpp
+++ b/esp32/PrimaryESP32/alphabot/Navigator.cpp
@@ -77,7 +77,7 @@ void Navigator::navigateStep(float dir, std::list<Coordinate>& path) {
         #endif
 
         int relative_dir = ((int)(next_dir - (((int)dir + 720) % 360) + 540) % 360) - 180;
-        int8_t speed = -65;
+        int8_t speed = 65;
 
         // If car would have to turn more than 90 degrees, drive backwards instead
         if (abs(relative_dir) > 90) {


### PR DESCRIPTION
Fix Alphabot driving in the wrong direction when navigating to a target.