### PR TITLE
clientLib: Fix positioning response interpretation

### DIFF
--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
@@ -53,7 +53,6 @@ namespace AlphabotClientLibrary.Core.Tcp
         private PositioningResponse GetPositioningResponse()
         {
             byte[] positioningBytes = new byte[4];
-
             Array.Copy(DataBytes, positioningBytes, 4);
 
             return new PositioningResponse(new Position(positioningBytes));

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using AlphabotClientLibrary.Shared;
 using AlphabotClientLibrary.Shared.Contracts;
+using AlphabotClientLibrary.Shared.Models;
 using AlphabotClientLibrary.Shared.Responses;
 
 namespace AlphabotClientLibrary.Core.Tcp
@@ -22,6 +23,8 @@ namespace AlphabotClientLibrary.Core.Tcp
             {
                 case 0x01:
                     return GetDistanceSensorResponse();
+                case 0x02:
+                    return GetPositioningResponse();
                 case 0x03:
                     return GetPathFindingResponse();
                 case 0x04:
@@ -45,6 +48,15 @@ namespace AlphabotClientLibrary.Core.Tcp
             ushort distance = (ushort)(DataBytes[2] | (DataBytes[3] << 8));
 
             return new DistanceSensorResponse(degree, distance);
+        }
+
+        private PositioningResponse GetPositioningResponse()
+        {
+            byte[] positioningBytes = new byte[4];
+
+            Array.Copy(DataBytes, positioningBytes, 4);
+
+            return new PositioningResponse(new Position(positioningBytes));
         }
 
         private CompassResponse GetCompassResponse()


### PR DESCRIPTION
Because it was accidently removed, when removing the request packet 0x02 in TCP