### PR TITLE
clients: Add response types and small changes

### DIFF
--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Contracts/IAlphabotResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Contracts/IAlphabotResponse.cs
@@ -2,6 +2,19 @@
 
 namespace AlphabotClientLibrary.Shared.Contracts
 {
+    public enum AlphabotResponseType
+    {
+        Compass,
+        DistanceSensor,
+        Error,
+        MultipleSensor,
+        NewObstacle,
+        PathFinding,
+        Ping,
+        Positioning,
+        Toggle
+    }
+
     public interface IAlphabotResponse
     {
     }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Contracts/IAlphabotResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Contracts/IAlphabotResponse.cs
@@ -17,5 +17,6 @@ namespace AlphabotClientLibrary.Shared.Contracts
 
     public interface IAlphabotResponse
     {
+        AlphabotResponseType GetResponseType();
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Models/WiFiConnectionData.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Models/WiFiConnectionData.cs
@@ -17,5 +17,17 @@ namespace AlphabotClientLibrary.Shared.Models
         {
             IPEndPoint = new IPEndPoint(ipaddress, port);
         }
+
+        public WiFiConnectionData(string address, ushort port)
+        {
+            IPAddress[] addresses = Dns.GetHostAddresses(address);
+
+            if(addresses.Length < 1)
+            {
+                throw new WebException("The address resolver could not resolve the host name.", WebExceptionStatus.NameResolutionFailure);
+            }
+
+            IPEndPoint = new IPEndPoint(addresses[0], port);
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Models/WiFiConnectionData.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Models/WiFiConnectionData.cs
@@ -23,9 +23,7 @@ namespace AlphabotClientLibrary.Shared.Models
             IPAddress[] addresses = Dns.GetHostAddresses(address);
 
             if(addresses.Length < 1)
-            {
                 throw new WebException("The address resolver could not resolve the host name.", WebExceptionStatus.NameResolutionFailure);
-            }
 
             IPEndPoint = new IPEndPoint(addresses[0], port);
         }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Requests/SpeedSteerRequest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Requests/SpeedSteerRequest.cs
@@ -6,13 +6,13 @@ namespace AlphabotClientLibrary.Shared.Requests
 {
     public class SpeedSteerRequest : IAlphabotRequest
     {
-        private sbyte _steer;
         private sbyte _speed;
+        private sbyte _steer;
 
-        public SpeedSteerRequest(sbyte steer, sbyte speed)
+        public SpeedSteerRequest(sbyte speed, sbyte steer)
         {
-            _steer = steer;
             _speed = speed;
+            _steer = steer;
         }
 
         public BleInformation GetBleInformation()

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/CompassResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/CompassResponse.cs
@@ -11,5 +11,10 @@ namespace AlphabotClientLibrary.Shared.Responses
         {
             Degree = degree;
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.Compass;
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/DistanceSensorResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/DistanceSensorResponse.cs
@@ -14,5 +14,10 @@ namespace AlphabotClientLibrary.Shared.Responses
             Degree = degree;
             Distance = distance;
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.DistanceSensor;
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/ErrorResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/ErrorResponse.cs
@@ -27,5 +27,10 @@ namespace AlphabotClientLibrary.Shared.Responses
             Array.Copy(packet, 1, Payload, 0, packet.Length - 1);
             Error = errorType;
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.Error;
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MultipleSensorResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MultipleSensorResponse.cs
@@ -24,5 +24,10 @@ namespace AlphabotClientLibrary.Shared.Responses
         {
             _sensorResponses = sensorResponses;
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.MultipleSensor;
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/NewObstacleRegisteredResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/NewObstacleRegisteredResponse.cs
@@ -12,5 +12,10 @@ namespace AlphabotClientLibrary.Shared.Responses
         {
             Obstacle = obstacle;
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.NewObstacle;
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PathFindingResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PathFindingResponse.cs
@@ -30,5 +30,10 @@ namespace AlphabotClientLibrary.Shared.Responses
             StartPositionY = startPositionY;
             Steps = pathFindingSteps;
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.PathFinding;
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PingResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PingResponse.cs
@@ -7,9 +7,12 @@ namespace AlphabotClientLibrary.Shared.Responses
     {
         public long Time { get; private set; }
 
+        public int Latency { get; private set; }
+
         public PingResponse(long time)
         {
             Time = time;
+            Latency = (int)(Time - DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
         }
 
         public AlphabotResponseType GetResponseType()

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PingResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PingResponse.cs
@@ -11,5 +11,10 @@ namespace AlphabotClientLibrary.Shared.Responses
         {
             Time = time;
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.Ping;
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PositioningResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PositioningResponse.cs
@@ -12,5 +12,10 @@ namespace AlphabotClientLibrary.Shared.Responses
         {
             Position = position;
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.Positioning;
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/TestResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/TestResponse.cs
@@ -9,5 +9,10 @@ namespace AlphabotClientLibrary.Shared.Responses
         {
             return "TestResponse.cs";
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/ToggleResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/ToggleResponse.cs
@@ -68,5 +68,10 @@ namespace AlphabotClientLibrary.Shared.Responses
             LogObstacleDistance = bitArray[14];
             LogPositioning = bitArray[15];
         }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.Toggle;
+        }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpRequestTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpRequestTest.cs
@@ -100,7 +100,7 @@ namespace AlphabotClientLibrary.Test
         [Fact]
         public void TestSpeedSteerRequest()
         {
-            SpeedSteerRequest request = new SpeedSteerRequest(50, -1);
+            SpeedSteerRequest request = new SpeedSteerRequest(-1, 50);
             byte[] expectedBytes = { 0x01, 0xFF, 0x32 };
 
             Assert.Equal(expectedBytes, request.GetBytes());


### PR DESCRIPTION
New features:

- Added response types as enum, and a public method GetResponseType() in the interface, to get the type of the response
- Added a third constructor in WiFiConnectionData with parameters string (IP as string format) and ushort (port)
- Added a latency property in PingResponse
- Changed the order of SpeedSteerRequest constructor so it fits the order of the name
- Change SpeedSteerRequest Test, because the parameter order was changed