### PR TITLE
clients: Fix responses

### DIFF
--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/AlphabotClientLibrary.Core.Tcp.csproj
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/AlphabotClientLibrary.Core.Tcp.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AlphabotClientLibrary.Core\AlphabotClientLibrary.Core.csproj" />
-    <ProjectReference Include="..\AlphabotClientLibrary.Shared\AlphabotClientLibrary.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/AlphabotClientLibrary.Core.Tcp.csproj
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/AlphabotClientLibrary.Core.Tcp.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AlphabotClientLibrary.Core\AlphabotClientLibrary.Core.csproj" />
+    <ProjectReference Include="..\AlphabotClientLibrary.Shared\AlphabotClientLibrary.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpHandlerWindows.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpHandlerWindows.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Sockets;
 using System.Threading;
 using AlphabotClientLibrary.Core.Handler;
@@ -57,7 +58,7 @@ namespace AlphabotClientLibrary.Core.Tcp
                 {
                     _tcpClient.GetStream().Read(data, 0, 1024);
                 }
-                catch (Exception e)
+                catch (IOException)
                 {
                     _tcpClient.Close();
                     return;

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpHandlerWindows.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpHandlerWindows.cs
@@ -43,7 +43,7 @@ namespace AlphabotClientLibrary.Core.Tcp
             if (_tcpClient == null || !_tcpClient.Connected || request == null)
                 return false;
 
-            _tcpClient.GetStream().Write(request.GetBytes());
+            _tcpClient.GetStream().Write(request.GetBytes(), 0, request.GetBytes().Length);
 
             return true;
         }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpHandlerWindows.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpHandlerWindows.cs
@@ -44,7 +44,8 @@ namespace AlphabotClientLibrary.Core.Tcp
             if (_tcpClient == null || !_tcpClient.Connected || request == null)
                 return false;
 
-            _tcpClient.GetStream().Write(request.GetBytes(), 0, request.GetBytes().Length);
+            byte[] requestBytes = request.GetBytes();
+            _tcpClient.GetStream().Write(requestBytes, 0, requestBytes.Length);
 
             return true;
         }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpHandlerWindows.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpHandlerWindows.cs
@@ -53,7 +53,15 @@ namespace AlphabotClientLibrary.Core.Tcp
             while (true)
             {
                 byte[] data = new byte[1024];
-                _tcpClient.GetStream().Read(data, 0, 1024);
+                try
+                {
+                    _tcpClient.GetStream().Read(data, 0, 1024);
+                }
+                catch (Exception e)
+                {
+                    _tcpClient.Close();
+                    return;
+                }
                 IAlphabotResponse alphabotResponse = new TcpResponseInterpreter(data).GetResponse();
                 IReadOnlyCollection<Response> responses = ResponseHandler.Listeners;
 

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
@@ -38,8 +38,8 @@ namespace AlphabotClientLibrary.Core.Tcp
                 case 0x08:
                     return GetErrorResponse();
             }
-
-            throw new Exception("Received packet id is not valid");
+            return new TestResponse();
+            //throw new Exception("Received packet id is not valid");
         }
 
         private DistanceSensorResponse GetDistanceSensorResponse()

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
@@ -21,6 +21,9 @@ namespace AlphabotClientLibrary.Core.Tcp
         {
             switch (_headerByte)
             {
+                case 0x00:
+                    // 0x00 gets sent, when a connection ends
+                    return null;
                 case 0x01:
                     return GetDistanceSensorResponse();
                 case 0x02:
@@ -38,8 +41,8 @@ namespace AlphabotClientLibrary.Core.Tcp
                 case 0x08:
                     return GetErrorResponse();
             }
-            return new TestResponse();
-            //throw new Exception("Received packet id is not valid");
+
+            throw new Exception("Received packet id is not valid");
         }
 
         private DistanceSensorResponse GetDistanceSensorResponse()

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core/AlphabotClientLibrary.Core.csproj
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core/AlphabotClientLibrary.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/AlphabotClientLibrary.Shared.csproj
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/AlphabotClientLibrary.Shared.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/ResponseInterpreter.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/ResponseInterpreter.cs
@@ -14,7 +14,7 @@ namespace AlphabotClientLibrary.Shared
 
         protected PingResponse GetPingResponse()
         {
-            long time = BitConverter.ToInt64(DataBytes);
+            long time = BitConverter.ToInt64(DataBytes, 0);
 
             return new PingResponse(time);
         }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PingResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/PingResponse.cs
@@ -12,7 +12,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         public PingResponse(long time)
         {
             Time = time;
-            Latency = (int)(Time - DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            Latency = (int)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - Time);
         }
 
         public AlphabotResponseType GetResponseType()

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test.Tcp.Server/Program.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test.Tcp.Server/Program.cs
@@ -31,7 +31,7 @@ namespace AlphabotClientLibrary.Test.Tcp.Server
                     StringBuilder receivedBytes = new StringBuilder("[CONNECTION]: Received the following bytes:");
 
                     foreach (var receivedByte in msg)
-                        sentBytes.AppendFormat(" 0x{0,2:X2},", receivedByte);
+                        receivedBytes.AppendFormat(" 0x{0,2:X2},", receivedByte);
 
                     Console.WriteLine(receivedBytes.ToString());
 


### PR DESCRIPTION
Closes #67 

Now where the Alphabot.NET understands the protocol, some bugs in the requests occurred, these will be fixed with that.

Bugs:
- Client crashes on TcpHandlerWindows.Disconnect() Method 
- PingResponse ctor sets the Latency negative instead of positive
- TcpResponseInterpreter throws an excpetion when wrong packet id is received
- for Xamarin .NET standard 2.0 downgrade is needed
- there is a wrong variable name in AlphabotClientLibrary.Test.Tcp.Server