### PR TITLE
docs/clients: Add missing sensor responses

### DIFF
--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
@@ -44,10 +44,18 @@ namespace AlphabotClientLibrary.Core.Tcp
                 case 0x0B:
                     return GetAccelerometerResponse();
                 case 0x0C:
+                    return GetMagnetometerResponse();
+                case 0x0D:
                     return GetErrorResponse();
             }
 
             throw new Exception("Received packet id is not valid");
+        }
+
+        private IAlphabotResponse GetMagnetometerResponse()
+        {
+            float[] axes = GetXYZAxes();
+            return new MagnetometerResponse(axes[0], axes[1], axes[2]);
         }
 
         private AccelerometerResponse GetAccelerometerResponse()

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
@@ -36,10 +36,45 @@ namespace AlphabotClientLibrary.Core.Tcp
                 case 0x07:
                     return GetToggleResponse();
                 case 0x08:
+                    return GetAnchorDistancesResponse();
+                case 0x09:
+                    return GetWheelSpeedResponse();
+                case 0x0A:
+                    return GetGyroscopeResponse();
+                case 0x0B:
+                    return GetAccelerometerResponse();
+                case 0x0C:
                     return GetErrorResponse();
             }
 
             throw new Exception("Received packet id is not valid");
+        }
+
+        private AccelerometerResponse GetAccelerometerResponse()
+        {
+            float[] axes = GetXYZAxes();
+            return new AccelerometerResponse(axes[0], axes[1], axes[2]);
+        }
+
+        private GyroscopeResponse GetGyroscopeResponse()
+        {
+            float[] axes = GetXYZAxes();
+            return new GyroscopeResponse(axes[0], axes[1], axes[2]);
+        }
+
+        private WheelSpeedResponse GetWheelSpeedResponse()
+        {
+            sbyte speed = (sbyte)(DataBytes[0]);
+            return new WheelSpeedResponse(speed);
+        }
+
+        private AnchorDistancesResponse GetAnchorDistancesResponse()
+        {
+            ushort distanceAnchor0 = (ushort)(DataBytes[0] | (DataBytes[1] << 8));
+            ushort distanceAnchor1 = (ushort)(DataBytes[2] | (DataBytes[3] << 8));
+            ushort distanceAnchor2 = (ushort)(DataBytes[4] | (DataBytes[5] << 8));
+
+            return new AnchorDistancesResponse(distanceAnchor0, distanceAnchor1, distanceAnchor2);
         }
 
         private DistanceSensorResponse GetDistanceSensorResponse()
@@ -62,6 +97,21 @@ namespace AlphabotClientLibrary.Core.Tcp
         {
             short degree = (short)(DataBytes[0] | (DataBytes[1] << 8));
             return new CompassResponse(degree);
+        }
+
+        private float[] GetXYZAxes()
+        {
+            byte[] xAxisBytes = new byte[4];
+            byte[] yAxisBytes = new byte[4];
+            byte[] zAxisBytes = new byte[4];
+            Array.Copy(DataBytes, 0, xAxisBytes, 0, 4);
+            Array.Copy(DataBytes, 4, yAxisBytes, 0, 4);
+            Array.Copy(DataBytes, 8, zAxisBytes, 0, 4);
+            float xAxis = BitConverter.ToSingle(xAxisBytes, 0);
+            float yAxis = BitConverter.ToSingle(yAxisBytes, 0);
+            float zAxis = BitConverter.ToSingle(zAxisBytes, 0);
+
+            return new float[] { xAxis, yAxis, zAxis };
         }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Core.Tcp/TcpResponseInterpreter.cs
@@ -54,20 +54,20 @@ namespace AlphabotClientLibrary.Core.Tcp
 
         private IAlphabotResponse GetMagnetometerResponse()
         {
-            float[] axes = GetXYZAxes();
-            return new MagnetometerResponse(axes[0], axes[1], axes[2]);
+            short[] axes = GetXYZAxes();
+            return new MagnetometerResponse(axes[0] / 10f, axes[1] / 10f, axes[2] / 10f);
         }
 
         private AccelerometerResponse GetAccelerometerResponse()
         {
-            float[] axes = GetXYZAxes();
-            return new AccelerometerResponse(axes[0], axes[1], axes[2]);
+            short[] axes = GetXYZAxes();
+            return new AccelerometerResponse(axes[0] / 1000f, axes[1] / 1000f, axes[2] / 1000f);
         }
 
         private GyroscopeResponse GetGyroscopeResponse()
         {
-            float[] axes = GetXYZAxes();
-            return new GyroscopeResponse(axes[0], axes[1], axes[2]);
+            short[] axes = GetXYZAxes();
+            return new GyroscopeResponse(axes[0] / 10f, axes[1] / 10f, axes[2] / 10f);
         }
 
         private WheelSpeedResponse GetWheelSpeedResponse()
@@ -107,19 +107,13 @@ namespace AlphabotClientLibrary.Core.Tcp
             return new CompassResponse(degree);
         }
 
-        private float[] GetXYZAxes()
+        private short[] GetXYZAxes()
         {
-            byte[] xAxisBytes = new byte[4];
-            byte[] yAxisBytes = new byte[4];
-            byte[] zAxisBytes = new byte[4];
-            Array.Copy(DataBytes, 0, xAxisBytes, 0, 4);
-            Array.Copy(DataBytes, 4, yAxisBytes, 0, 4);
-            Array.Copy(DataBytes, 8, zAxisBytes, 0, 4);
-            float xAxis = BitConverter.ToSingle(xAxisBytes, 0);
-            float yAxis = BitConverter.ToSingle(yAxisBytes, 0);
-            float zAxis = BitConverter.ToSingle(zAxisBytes, 0);
+            short xAxis = (short)(DataBytes[0] | (DataBytes[1] << 8));
+            short yAxis = (short)(DataBytes[2] | (DataBytes[3] << 8));
+            short zAxis = (short)(DataBytes[4] | (DataBytes[5] << 8));
 
-            return new float[] { xAxis, yAxis, zAxis };
+            return new short[] { xAxis, yAxis, zAxis };
         }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Contracts/IAlphabotResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Contracts/IAlphabotResponse.cs
@@ -12,7 +12,11 @@ namespace AlphabotClientLibrary.Shared.Contracts
         PathFinding,
         Ping,
         Positioning,
-        Toggle
+        Toggle,
+        AnchorDistances,
+        WheelSpeed,
+        Gyroscope,
+        Accelerometer
     }
 
     public interface IAlphabotResponse

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Contracts/IAlphabotResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Contracts/IAlphabotResponse.cs
@@ -16,7 +16,8 @@ namespace AlphabotClientLibrary.Shared.Contracts
         AnchorDistances,
         WheelSpeed,
         Gyroscope,
-        Accelerometer
+        Accelerometer,
+        Magnetometer
     }
 
     public interface IAlphabotResponse

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Requests/ToggleRequest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Requests/ToggleRequest.cs
@@ -32,9 +32,7 @@ namespace AlphabotClientLibrary.Shared.Requests
 
         public bool LogWheelSpeed { get; set; }
 
-        public bool LogAccelerometer { get; set; }
-
-        public bool LogGyroscope { get; set; }
+        public bool LogIMU { get; set; }
         #endregion
 
         public ToggleRequest(ushort bitField)
@@ -50,8 +48,8 @@ namespace AlphabotClientLibrary.Shared.Requests
             DoInvite = bitArray[6];
             DoCompassCalibration = bitArray[7];
 
-            LogGyroscope = bitArray[8];
-            LogAccelerometer = bitArray[9];
+            // Bit 8 is not used.
+            LogIMU = bitArray[9];
             LogWheelSpeed = bitArray[10];
             LogAnchorDistances = bitArray[11];
             LogCompassDirection = bitArray[12];
@@ -89,8 +87,8 @@ namespace AlphabotClientLibrary.Shared.Requests
             bitArray[6] = DoInvite;
             bitArray[7] = DoCompassCalibration;
 
-            bitArray[8] = LogGyroscope;
-            bitArray[9] = LogAccelerometer;
+            // Bit 8 is not used.
+            bitArray[9] = LogIMU;
             bitArray[10] = LogWheelSpeed;
             bitArray[11] = LogAnchorDistances;
             bitArray[12] = LogCompassDirection;

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
@@ -6,8 +6,17 @@ namespace AlphabotClientLibrary.Shared.Responses
 {
     public class AccelerometerResponse : IAlphabotResponse
     {
+        /// <summary>
+        /// The acceleration in m/s²
+        /// </summary>
         public float XAxis { get; private set; }
+        /// <summary>
+        /// The acceleration in m/s²
+        /// </summary>
         public float YAxis { get; private set; }
+        /// <summary>
+        /// The acceleration in m/s²
+        /// </summary>
         public float ZAxis { get; private set; }
 
         public AccelerometerResponse(float xAxis, float yAxis, float zAxis)

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
@@ -7,7 +7,7 @@ namespace AlphabotClientLibrary.Shared.Responses
     public class AccelerometerResponse : IAlphabotResponse
     {
         /// <summary>
-        /// The acceleration in m/s²
+        /// The acceleration in m/s^2
         /// </summary>
         public float XAxis { get; private set; }
         /// <summary>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AlphabotClientLibrary.Shared.Contracts;
-using AlphabotClientLibrary.Shared.Models;
 
 namespace AlphabotClientLibrary.Shared.Responses
 {

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
@@ -15,6 +15,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         /// The acceleration in m/s^2
         /// </summary>
         public float YAxis { get; private set; }
+
         /// <summary>
         /// The acceleration in m/s^2
         /// </summary>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using AlphabotClientLibrary.Shared.Contracts;
+using AlphabotClientLibrary.Shared.Models;
+
+namespace AlphabotClientLibrary.Shared.Responses
+{
+    public class AccelerometerResponse : IAlphabotResponse
+    {
+        public float XAxis { get; private set; }
+        public float YAxis { get; private set; }
+        public float ZAxis { get; private set; }
+
+        public AccelerometerResponse(float xAxis, float yAxis, float zAxis)
+        {
+            XAxis = xAxis;
+            YAxis = yAxis;
+            ZAxis = zAxis;
+        }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.Accelerometer;
+        }
+    }
+}

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
@@ -15,7 +15,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         /// </summary>
         public float YAxis { get; private set; }
         /// <summary>
-        /// The acceleration in m/s²
+        /// The acceleration in m/s^2
         /// </summary>
         public float ZAxis { get; private set; }
 

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
@@ -10,6 +10,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         /// The acceleration in m/s^2
         /// </summary>
         public float XAxis { get; private set; }
+
         /// <summary>
         /// The acceleration in m/s^2
         /// </summary>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AccelerometerResponse.cs
@@ -11,7 +11,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         /// </summary>
         public float XAxis { get; private set; }
         /// <summary>
-        /// The acceleration in m/s²
+        /// The acceleration in m/s^2
         /// </summary>
         public float YAxis { get; private set; }
         /// <summary>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AnchorDistancesResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AnchorDistancesResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AlphabotClientLibrary.Shared.Contracts;
-using AlphabotClientLibrary.Shared.Models;
 
 namespace AlphabotClientLibrary.Shared.Responses
 {

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AnchorDistancesResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AnchorDistancesResponse.cs
@@ -7,7 +7,9 @@ namespace AlphabotClientLibrary.Shared.Responses
     public class AnchorDistancesResponse : IAlphabotResponse
     {
         public ushort DistanceAnchor0 { get; private set; }
+        
         public ushort DistanceAnchor1 { get; private set; }
+        
         public ushort DistanceAnchor2 { get; private set; }
 
         public AnchorDistancesResponse(ushort distanceAnchor0, ushort distanceAnchor1, ushort distanceAnchor2)

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AnchorDistancesResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/AnchorDistancesResponse.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using AlphabotClientLibrary.Shared.Contracts;
+using AlphabotClientLibrary.Shared.Models;
+
+namespace AlphabotClientLibrary.Shared.Responses
+{
+    public class AnchorDistancesResponse : IAlphabotResponse
+    {
+        public ushort DistanceAnchor0 { get; private set; }
+        public ushort DistanceAnchor1 { get; private set; }
+        public ushort DistanceAnchor2 { get; private set; }
+
+        public AnchorDistancesResponse(ushort distanceAnchor0, ushort distanceAnchor1, ushort distanceAnchor2)
+        {
+            DistanceAnchor0 = distanceAnchor0;
+            DistanceAnchor1 = distanceAnchor1;
+            DistanceAnchor2 = distanceAnchor2;
+        }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.AnchorDistances;
+        }
+    }
+}

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
@@ -7,7 +7,7 @@ namespace AlphabotClientLibrary.Shared.Responses
     public class GyroscopeResponse : IAlphabotResponse
     {
         /// <summary>
-        /// The speed in degree per second
+        /// The speed in degrees per second
         /// </summary>
 
         public float XAxis { get; private set; }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
@@ -14,6 +14,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         /// <summary>
         /// The speed in degree per second
         /// </summary>
+
         public float YAxis { get; private set; }
         /// <summary>
         /// The speed in degree per second

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
@@ -6,8 +6,17 @@ namespace AlphabotClientLibrary.Shared.Responses
 {
     public class GyroscopeResponse : IAlphabotResponse
     {
+        /// <summary>
+        /// The speed in degree per second
+        /// </summary>
         public float XAxis { get; private set; }
+        /// <summary>
+        /// The speed in degree per second
+        /// </summary>
         public float YAxis { get; private set; }
+        /// <summary>
+        /// The speed in degree per second
+        /// </summary>
         public float ZAxis { get; private set; }
 
         public GyroscopeResponse(float xAxis, float yAxis, float zAxis)

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
@@ -9,6 +9,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         /// <summary>
         /// The speed in degree per second
         /// </summary>
+
         public float XAxis { get; private set; }
         /// <summary>
         /// The speed in degree per second

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AlphabotClientLibrary.Shared.Contracts;
-using AlphabotClientLibrary.Shared.Models;
 
 namespace AlphabotClientLibrary.Shared.Responses
 {

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
@@ -12,7 +12,7 @@ namespace AlphabotClientLibrary.Shared.Responses
 
         public float XAxis { get; private set; }
         /// <summary>
-        /// The speed in degree per second
+        /// The speed in degrees per second
         /// </summary>
 
         public float YAxis { get; private set; }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
@@ -17,7 +17,7 @@ namespace AlphabotClientLibrary.Shared.Responses
 
         public float YAxis { get; private set; }
         /// <summary>
-        /// The speed in degree per second
+        /// The speed in degrees per second
         /// </summary>
         public float ZAxis { get; private set; }
 

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/GyroscopeResponse.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using AlphabotClientLibrary.Shared.Contracts;
+using AlphabotClientLibrary.Shared.Models;
+
+namespace AlphabotClientLibrary.Shared.Responses
+{
+    public class GyroscopeResponse : IAlphabotResponse
+    {
+        public float XAxis { get; private set; }
+        public float YAxis { get; private set; }
+        public float ZAxis { get; private set; }
+
+        public GyroscopeResponse(float xAxis, float yAxis, float zAxis)
+        {
+            XAxis = xAxis;
+            YAxis = yAxis;
+            ZAxis = zAxis;
+        }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.Gyroscope;
+        }
+    }
+}

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
@@ -12,7 +12,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         public float XAxis { get; private set; }
 
         /// <summary>
-        /// The magnetic flux density in µT
+        /// The magnetic flux density in Microtesla
         /// </summary>
         public float YAxis { get; private set; }
 

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
@@ -6,8 +6,17 @@ namespace AlphabotClientLibrary.Shared.Responses
 {
     public class MagnetometerResponse : IAlphabotResponse
     {
+        /// <summary>
+        /// The magnetic flux density in µT
+        /// </summary>
         public float XAxis { get; private set; }
+        /// <summary>
+        /// The magnetic flux density in µT
+        /// </summary>
         public float YAxis { get; private set; }
+        /// <summary>
+        /// The magnetic flux density in µT
+        /// </summary>
         public float ZAxis { get; private set; }
 
         public MagnetometerResponse(float xAxis, float yAxis, float zAxis)

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
@@ -15,6 +15,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         /// The magnetic flux density in µT
         /// </summary>
         public float YAxis { get; private set; }
+
         /// <summary>
         /// The magnetic flux density in µT
         /// </summary>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
@@ -17,7 +17,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         public float YAxis { get; private set; }
 
         /// <summary>
-        /// The magnetic flux density in µT
+        /// The magnetic flux density in Microtesla
         /// </summary>
         public float ZAxis { get; private set; }
 

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AlphabotClientLibrary.Shared.Contracts;
-using AlphabotClientLibrary.Shared.Models;
 
 namespace AlphabotClientLibrary.Shared.Responses
 {

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
@@ -10,6 +10,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         /// The magnetic flux density in µT
         /// </summary>
         public float XAxis { get; private set; }
+
         /// <summary>
         /// The magnetic flux density in µT
         /// </summary>

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using AlphabotClientLibrary.Shared.Contracts;
+using AlphabotClientLibrary.Shared.Models;
+
+namespace AlphabotClientLibrary.Shared.Responses
+{
+    public class MagnetometerResponse : IAlphabotResponse
+    {
+        public float XAxis { get; private set; }
+        public float YAxis { get; private set; }
+        public float ZAxis { get; private set; }
+
+        public MagnetometerResponse(float xAxis, float yAxis, float zAxis)
+        {
+            XAxis = xAxis;
+            YAxis = yAxis;
+            ZAxis = zAxis;
+        }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.Magnetometer;
+        }
+    }
+}

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/MagnetometerResponse.cs
@@ -7,7 +7,7 @@ namespace AlphabotClientLibrary.Shared.Responses
     public class MagnetometerResponse : IAlphabotResponse
     {
         /// <summary>
-        /// The magnetic flux density in µT
+        /// The magnetic flux density in Microtesla
         /// </summary>
         public float XAxis { get; private set; }
 

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/ToggleResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/ToggleResponse.cs
@@ -31,9 +31,7 @@ namespace AlphabotClientLibrary.Shared.Responses
 
         public bool LogWheelSpeed { get; private set; }
 
-        public bool LogAccelerometer { get; private set; }
-
-        public bool LogGyroscope { get; private set; }
+        public bool LogIMU { get; private set; }
         #endregion
 
         public ToggleResponse(ushort bitField)
@@ -51,7 +49,7 @@ namespace AlphabotClientLibrary.Shared.Responses
         {
             BitArray bitArray = new BitArray(bytes);
 
-            //bit 0 and 1 are not used
+            // Bit 0 and 1 are not used.
             DoExploreMode = bitArray[2];
             DoNavigationMode = bitArray[3];
             DoCollisionAvoidance = bitArray[4];
@@ -59,8 +57,8 @@ namespace AlphabotClientLibrary.Shared.Responses
             DoInvite = bitArray[6];
             DoCompassCalibration = bitArray[7];
 
-            LogGyroscope = bitArray[8];
-            LogAccelerometer = bitArray[9];
+            // Bit 8 is not used.
+            LogIMU = bitArray[9];
             LogWheelSpeed = bitArray[10];
             LogAnchorDistances = bitArray[11];
             LogCompassDirection = bitArray[12];

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/WheelSpeedResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/WheelSpeedResponse.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using AlphabotClientLibrary.Shared.Contracts;
+using AlphabotClientLibrary.Shared.Models;
+
+namespace AlphabotClientLibrary.Shared.Responses
+{
+    public class WheelSpeedResponse : IAlphabotResponse
+    {
+        /// <summary>
+        /// Speed in meters per second
+        /// </summary>
+        public sbyte Speed { get; private set; }
+
+        public WheelSpeedResponse(sbyte speed)
+        {
+            Speed = speed;
+        }
+
+        public AlphabotResponseType GetResponseType()
+        {
+            return AlphabotResponseType.WheelSpeed;
+        }
+    }
+}

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/WheelSpeedResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/WheelSpeedResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using AlphabotClientLibrary.Shared.Contracts;
-using AlphabotClientLibrary.Shared.Models;
 
 namespace AlphabotClientLibrary.Shared.Responses
 {

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpRequestTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpRequestTest.cs
@@ -114,7 +114,7 @@ namespace AlphabotClientLibrary.Test
             request.LogPositioning = true;
             request.LogIMU = true;
 
-            byte[] expectedBytes = { 0x05, 0x08, 0x81 };
+            byte[] expectedBytes = { 0x05, 0x08, 0x82 };
 
             Assert.Equal(expectedBytes, request.GetBytes());
         }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpRequestTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpRequestTest.cs
@@ -112,9 +112,9 @@ namespace AlphabotClientLibrary.Test
             ToggleRequest request = new ToggleRequest(0);
             request.DoExploreMode = true;
             request.LogPositioning = true;
-            request.LogGyroscope = true;
+            request.LogIMU = true;
 
-            byte[] expectedBytes = { 0x05, 0x04, 0x81 };
+            byte[] expectedBytes = { 0x05, 0x04, 0x82 };
 
             Assert.Equal(expectedBytes, request.GetBytes());
         }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -14,12 +14,12 @@ namespace AlphabotClientLibrary.Test
         [Fact]
         public void TestAccelerometerResponse()
         {
-            float expectedX = 7883.99f;
-            float expectedY = -2428426.234f;
-            float expectedZ = 0.00000002f;
-            byte[] xBytes = BitConverter.GetBytes(expectedX);
-            byte[] yBytes = BitConverter.GetBytes(expectedY);
-            byte[] zBytes = BitConverter.GetBytes(expectedZ);
+            float expectedX = 5.035351242f;
+            float expectedY = -6.0001f;
+            float expectedZ = 13.4f;
+            byte[] xBytes = BitConverter.GetBytes(Convert.ToInt16(expectedX * 1000));
+            byte[] yBytes = BitConverter.GetBytes(Convert.ToInt16(expectedY * 1000));
+            byte[] zBytes = BitConverter.GetBytes(Convert.ToInt16(expectedZ * 1000));
 
             byte[] packetHeader = { 0x0B };
             byte[] responseBytes;
@@ -30,9 +30,9 @@ namespace AlphabotClientLibrary.Test
             Assert.True(response is AccelerometerResponse, "Response was of the wrong type");
 
             AccelerometerResponse accelerometerResponse = response as AccelerometerResponse;
-            Assert.Equal(expectedX, accelerometerResponse.XAxis);
-            Assert.Equal(expectedY, accelerometerResponse.YAxis);
-            Assert.Equal(expectedZ, accelerometerResponse.ZAxis);
+            Assert.InRange(accelerometerResponse.XAxis, expectedX - 0.1, expectedX + 0.1);
+            Assert.InRange(accelerometerResponse.YAxis, expectedY - 0.1, expectedY + 0.1);
+            Assert.InRange(accelerometerResponse.ZAxis, expectedZ - 0.1, expectedZ + 0.1);
         }
 
         [Fact]
@@ -100,12 +100,12 @@ namespace AlphabotClientLibrary.Test
         [Fact]
         public void TestGyroscopeResponse()
         {
-            float expectedX = 1400524.8004f;
-            float expectedY = 400.0f;
-            float expectedZ = -0.0102052f;
-            byte[] xBytes = BitConverter.GetBytes(expectedX);
-            byte[] yBytes = BitConverter.GetBytes(expectedY);
-            byte[] zBytes = BitConverter.GetBytes(expectedZ);
+            float expectedX = -24.298f;
+            float expectedY = -8.0001f;
+            float expectedZ = 1113.75f;
+            byte[] xBytes = BitConverter.GetBytes(Convert.ToInt16(expectedX * 10));
+            byte[] yBytes = BitConverter.GetBytes(Convert.ToInt16(expectedY * 10));
+            byte[] zBytes = BitConverter.GetBytes(Convert.ToInt16(expectedZ * 10));
 
             byte[] packetHeader = { 0x0A };
             byte[] responseBytes;
@@ -116,20 +116,20 @@ namespace AlphabotClientLibrary.Test
             Assert.True(response is GyroscopeResponse, "Response was of the wrong type");
 
             GyroscopeResponse gyroscopeResponse = response as GyroscopeResponse;
-            Assert.Equal(expectedX, gyroscopeResponse.XAxis);
-            Assert.Equal(expectedY, gyroscopeResponse.YAxis);
-            Assert.Equal(expectedZ, gyroscopeResponse.ZAxis);
+            Assert.InRange(gyroscopeResponse.XAxis, expectedX - 0.1, expectedX + 0.1);
+            Assert.InRange(gyroscopeResponse.YAxis, expectedY - 0.1, expectedY + 0.1);
+            Assert.InRange(gyroscopeResponse.ZAxis, expectedZ - 0.1, expectedZ + 0.1);
         }
 
         [Fact]
         public void TestMagnetometerResponse()
         {
-            float expectedX = 3582958295.0f;
-            float expectedY = -232.232f;
-            float expectedZ = 0.012345f;
-            byte[] xBytes = BitConverter.GetBytes(expectedX);
-            byte[] yBytes = BitConverter.GetBytes(expectedY);
-            byte[] zBytes = BitConverter.GetBytes(expectedZ);
+            float expectedX = 340.09f;
+            float expectedY = -81.1f;
+            float expectedZ = 78.751f;
+            byte[] xBytes = BitConverter.GetBytes(Convert.ToInt16(expectedX * 10));
+            byte[] yBytes = BitConverter.GetBytes(Convert.ToInt16(expectedY * 10));
+            byte[] zBytes = BitConverter.GetBytes(Convert.ToInt16(expectedZ * 10));
 
             byte[] packetHeader = { 0x0C };
             byte[] responseBytes;
@@ -140,9 +140,9 @@ namespace AlphabotClientLibrary.Test
             Assert.True(response is MagnetometerResponse, "Response was of the wrong type");
 
             MagnetometerResponse magnetometerResponse = response as MagnetometerResponse;
-            Assert.Equal(expectedX, magnetometerResponse.XAxis);
-            Assert.Equal(expectedY, magnetometerResponse.YAxis);
-            Assert.Equal(expectedZ, magnetometerResponse.ZAxis);
+            Assert.InRange(magnetometerResponse.XAxis, expectedX - 0.1, expectedX + 0.1);
+            Assert.InRange(magnetometerResponse.YAxis, expectedY - 0.1, expectedY + 0.1);
+            Assert.InRange(magnetometerResponse.ZAxis, expectedZ - 0.1, expectedZ + 0.1);
         }
 
         [Fact]

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -12,6 +12,47 @@ namespace AlphabotClientLibrary.Test
     public class TcpResponseTest
     {
         [Fact]
+        public void TestAccelerometerResponse()
+        {
+            float expectedX = 7883.99f;
+            float expectedY = -2428426.234f;
+            float expectedZ = 0.00000002f;
+            byte[] xBytes = BitConverter.GetBytes(expectedX);
+            byte[] yBytes = BitConverter.GetBytes(expectedY);
+            byte[] zBytes = BitConverter.GetBytes(expectedZ);
+
+            byte[] packetHeader = { 0x0B };
+            byte[] responseBytes;
+
+            responseBytes = packetHeader.Concat(xBytes).Concat(yBytes).Concat(zBytes).ToArray();
+
+            IAlphabotResponse response = new TcpResponseInterpreter(responseBytes).GetResponse();
+            Assert.True(response is AccelerometerResponse, "Response was of the wrong type");
+
+            AccelerometerResponse accelerometerResponse = response as AccelerometerResponse;
+            Assert.Equal(expectedX, accelerometerResponse.XAxis);
+            Assert.Equal(expectedY, accelerometerResponse.YAxis);
+            Assert.Equal(expectedZ, accelerometerResponse.ZAxis);
+        }
+
+        [Fact]
+        public void TestAnchorDistancesResponse()
+        {
+            byte[] bytes = { 0x08, 0x6F, 0x00, 0xAE, 0x08, 0x35, 0x82 };
+            ushort expectedDistance0 = 111;
+            ushort expectedDistance1 = 2222;
+            ushort expectedDistance2 = 33333;
+
+            IAlphabotResponse response = new TcpResponseInterpreter(bytes).GetResponse();
+            Assert.True(response is AnchorDistancesResponse, "Response was of the wrong type");
+
+            AnchorDistancesResponse anchorDistanceResponse = response as AnchorDistancesResponse;
+            Assert.Equal(expectedDistance0, anchorDistanceResponse.DistanceAnchor0);
+            Assert.Equal(expectedDistance1, anchorDistanceResponse.DistanceAnchor1);
+            Assert.Equal(expectedDistance2, anchorDistanceResponse.DistanceAnchor2);
+        }
+
+        [Fact]
         public void TestCompassResponse()
         {
             byte[] bytes = { 0x04, 0x64, 0x00 };
@@ -54,6 +95,30 @@ namespace AlphabotClientLibrary.Test
             Assert.Equal(expectedErrorType, errorResponse.Error);
             Assert.Equal(expectedHeader, errorResponse.Header);
             Assert.Equal(expectedPayload, errorResponse.Payload);
+        }
+
+        [Fact]
+        public void TestGyroscopeResponse()
+        {
+            float expectedX = 1400524.8004f;
+            float expectedY = 400.0f;
+            float expectedZ = -0.0102052f;
+            byte[] xBytes = BitConverter.GetBytes(expectedX);
+            byte[] yBytes = BitConverter.GetBytes(expectedY);
+            byte[] zBytes = BitConverter.GetBytes(expectedZ);
+
+            byte[] packetHeader = { 0x0A };
+            byte[] responseBytes;
+
+            responseBytes = packetHeader.Concat(xBytes).Concat(yBytes).Concat(zBytes).ToArray();
+
+            IAlphabotResponse response = new TcpResponseInterpreter(responseBytes).GetResponse();
+            Assert.True(response is GyroscopeResponse, "Response was of the wrong type");
+
+            GyroscopeResponse gyroscopeResponse = response as GyroscopeResponse;
+            Assert.Equal(expectedX, gyroscopeResponse.XAxis);
+            Assert.Equal(expectedY, gyroscopeResponse.YAxis);
+            Assert.Equal(expectedZ, gyroscopeResponse.ZAxis);
         }
 
         [Fact]
@@ -151,6 +216,19 @@ namespace AlphabotClientLibrary.Test
             Assert.True(toggleResponse.DoPositioningSystem);
             Assert.True(toggleResponse.LogPathfinderPath);
             Assert.True(toggleResponse.LogCompassDirection);
+        }
+
+        [Fact]
+        public void TestWheelSpeedResponse()
+        {
+            byte[] bytes = { 0x09, 0x68 };
+            int expectedSpeed = 104;
+
+            IAlphabotResponse response = new TcpResponseInterpreter(bytes).GetResponse();
+            Assert.True(response is WheelSpeedResponse, "Response was of the wrong type");
+
+            WheelSpeedResponse wheelSpeedResponse = response as WheelSpeedResponse;
+            Assert.Equal(expectedSpeed, wheelSpeedResponse.Speed);
         }
     }
 }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -122,6 +122,30 @@ namespace AlphabotClientLibrary.Test
         }
 
         [Fact]
+        public void TestMagnetometerResponse()
+        {
+            float expectedX = 3582958295.0f;
+            float expectedY = -232.232f;
+            float expectedZ = 0.012345f;
+            byte[] xBytes = BitConverter.GetBytes(expectedX);
+            byte[] yBytes = BitConverter.GetBytes(expectedY);
+            byte[] zBytes = BitConverter.GetBytes(expectedZ);
+
+            byte[] packetHeader = { 0x0C };
+            byte[] responseBytes;
+
+            responseBytes = packetHeader.Concat(xBytes).Concat(yBytes).Concat(zBytes).ToArray();
+
+            IAlphabotResponse response = new TcpResponseInterpreter(responseBytes).GetResponse();
+            Assert.True(response is MagnetometerResponse, "Response was of the wrong type");
+
+            MagnetometerResponse magnetometerResponse = response as MagnetometerResponse;
+            Assert.Equal(expectedX, magnetometerResponse.XAxis);
+            Assert.Equal(expectedY, magnetometerResponse.YAxis);
+            Assert.Equal(expectedZ, magnetometerResponse.ZAxis);
+        }
+
+        [Fact]
         public void TestNewObstacleRegisteredResponse()
         {
             byte[] bytes = { 0x06, 0x10, 0x10, 0x08, 0x08, 0x0A, 0x00, 0x14, 0x00, 0x05, 0x00 };

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -128,9 +128,7 @@ namespace AlphabotClientLibrary.Test
             byte[] zBytes = BitConverter.GetBytes(Convert.ToInt16(expectedZ * 10));
 
             byte[] packetHeader = { 0x0C };
-            byte[] responseBytes;
-
-            responseBytes = packetHeader.Concat(xBytes).Concat(yBytes).Concat(zBytes).ToArray();
+            byte[] responseBytes = packetHeader.Concat(xBytes).Concat(yBytes).Concat(zBytes).ToArray();
 
             IAlphabotResponse response = new TcpResponseInterpreter(responseBytes).GetResponse();
             Assert.True(response is MagnetometerResponse, "Response was of the wrong type");

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -22,9 +22,7 @@ namespace AlphabotClientLibrary.Test
             byte[] zBytes = BitConverter.GetBytes(Convert.ToInt16(expectedZ * 1000));
 
             byte[] packetHeader = { 0x0B };
-            byte[] responseBytes;
-
-            responseBytes = packetHeader.Concat(xBytes).Concat(yBytes).Concat(zBytes).ToArray();
+            byte[] responseBytes = packetHeader.Concat(xBytes).Concat(yBytes).Concat(zBytes).ToArray();
 
             IAlphabotResponse response = new TcpResponseInterpreter(responseBytes).GetResponse();
             Assert.True(response is AccelerometerResponse, "Response was of the wrong type");

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -83,7 +83,7 @@ namespace AlphabotClientLibrary.Test
         [Fact]
         public void TestErrorResponse()
         {
-            byte[] bytes = { 0x0C, 0x03, 0x0E, 0x01, 0x02, 0x03, 0x04, 0x05 };
+            byte[] bytes = { 0x0D, 0x03, 0x0E, 0x01, 0x02, 0x03, 0x04, 0x05 };
             ErrorResponse.ErrorType expectedErrorType = ErrorResponse.ErrorType.UnknownPacketId;
             byte expectedHeader = 14;
             byte[] expectedPayload = { 0x01, 0x02, 0x03, 0x04, 0x05 };

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -28,9 +28,9 @@ namespace AlphabotClientLibrary.Test
             Assert.True(response is AccelerometerResponse, "Response was of the wrong type");
 
             AccelerometerResponse accelerometerResponse = response as AccelerometerResponse;
-            Assert.InRange(accelerometerResponse.XAxis, expectedX - 0.1, expectedX + 0.1);
-            Assert.InRange(accelerometerResponse.YAxis, expectedY - 0.1, expectedY + 0.1);
-            Assert.InRange(accelerometerResponse.ZAxis, expectedZ - 0.1, expectedZ + 0.1);
+            Assert.InRange(accelerometerResponse.XAxis, expectedX - 0.001, expectedX + 0.001);
+            Assert.InRange(accelerometerResponse.YAxis, expectedY - 0.001, expectedY + 0.001);
+            Assert.InRange(accelerometerResponse.ZAxis, expectedZ - 0.001, expectedZ + 0.001);
         }
 
         [Fact]

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -106,9 +106,7 @@ namespace AlphabotClientLibrary.Test
             byte[] zBytes = BitConverter.GetBytes(Convert.ToInt16(expectedZ * 10));
 
             byte[] packetHeader = { 0x0A };
-            byte[] responseBytes;
-
-            responseBytes = packetHeader.Concat(xBytes).Concat(yBytes).Concat(zBytes).ToArray();
+            byte[] responseBytes = packetHeader.Concat(xBytes).Concat(yBytes).Concat(zBytes).ToArray();
 
             IAlphabotResponse response = new TcpResponseInterpreter(responseBytes).GetResponse();
             Assert.True(response is GyroscopeResponse, "Response was of the wrong type");

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -42,7 +42,7 @@ namespace AlphabotClientLibrary.Test
         [Fact]
         public void TestErrorResponse()
         {
-            byte[] bytes = { 0x08, 0x03, 0x0E, 0x01, 0x02, 0x03, 0x04, 0x05 };
+            byte[] bytes = { 0x0C, 0x03, 0x0E, 0x01, 0x02, 0x03, 0x04, 0x05 };
             ErrorResponse.ErrorType expectedErrorType = ErrorResponse.ErrorType.UnknownPacketId;
             byte expectedHeader = 14;
             byte[] expectedPayload = { 0x01, 0x02, 0x03, 0x04, 0x05 };

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -162,27 +162,27 @@ see [3.1. Toggle bit field](#31-toggle---bit-field)
 
 ### Gyroscope response (Packet ID: 0x0A)
 
-| Field Name | Field Type | Notes                            |
-|------------|------------|----------------------------------|
-| X-axis     | float      | The speed of the x-axis in rad/s |
-| Y-axis     | float      | The speed of the y-axis in rad/s |
-| Z-axis     | float      | The speed of the z-axis in rad/s |
+| Field Name | Field Type | Notes                                    |
+|------------|------------|------------------------------------------|
+| X-axis     | int16      | The speed of the x-axis in degree/s * 10 |
+| Y-axis     | int16      | The speed of the y-axis in degree/s * 10 |
+| Z-axis     | int16      | The speed of the z-axis in degree/s * 10 |
 
 ### Accelerometer response (Packet ID: 0x0B)
 
-| Field Name | Field Type | Notes                                  |
-|------------|------------|----------------------------------------|
-| X-axis     | float      | The acceleration of the x-axis in m/s² |
-| Y-axis     | float      | The acceleration of the y-axis in m/s² |
-| Z-axis     | float      | The acceleration of the z-axis in m/s² |
+| Field Name | Field Type | Notes                                         |
+|------------|------------|-----------------------------------------------|
+| X-axis     | int16      | The acceleration of the x-axis in m/s² * 1000 |
+| Y-axis     | int16      | The acceleration of the y-axis in m/s² * 1000 |
+| Z-axis     | int16      | The acceleration of the z-axis in m/s² * 1000 |
 
 ### Magnetometer response (Packet ID: 0x0C)
 
-| Field Name | Field Type | Notes                               |
-|------------|------------|-------------------------------------|
-| X-axis     | float      | The acceleration of the x-axis in T |
-| Y-axis     | float      | The acceleration of the y-axis in T |
-| Z-axis     | float      | The acceleration of the z-axis in T |
+| Field Name | Field Type | Notes                                              |
+|------------|------------|----------------------------------------------------|
+| X-axis     | int16      | The magnetic flux density of the x-axis in µT * 10 |
+| Y-axis     | int16      | The magnetic flux density of the y-axis in µT * 10 |
+| Z-axis     | int16      | The magnetic flux density of the z-axis in µT * 10 |
 
 ### Error message (Packet ID: 0x0D)
 
@@ -303,9 +303,9 @@ If there are multiple objects on the same position, all of them will be removed.
 | Field Name | Field Type | Notes                                                                                                                                   |
 |------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | Type       | int8       | Indicates whether the packet is a gyroscope-package (value 0), an accelerometer-package (value 1), or an magnetometer-package (value 2) |
-| x-Axis     | float      | The value of the x-Axis                                                                                                                 |
-| y-Axis     | float      | The value of the y-Axis                                                                                                                 |
-| z-Axis     | float      | The value of the z-Axis                                                                                                                 |
+| x-Axis     | int16      | The value of the x-Axis                                                                                                                 |
+| y-Axis     | int16      | The value of the y-Axis                                                                                                                 |
+| z-Axis     | int16      | The value of the z-Axis                                                                                                                 |
 
 ### BLE_CHAR_ERROR (UUID: dc458f08-ea3e-4fe1-adb3-25c840be081a)
 

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -172,9 +172,9 @@ see [3.1. Toggle bit field](#31-toggle---bit-field)
 
 | Field Name | Field Type | Notes                                         |
 |------------|------------|-----------------------------------------------|
-| X-axis     | int16      | The acceleration of the x-axis in m/s² * 1000 |
-| Y-axis     | int16      | The acceleration of the y-axis in m/s² * 1000 |
-| Z-axis     | int16      | The acceleration of the z-axis in m/s² * 1000 |
+| X-axis     | int16      | The acceleration of the x-axis in m/s&#xB2; * 1000 |
+| Y-axis     | int16      | The acceleration of the y-axis in m/s&#xB2; * 1000 |
+| Z-axis     | int16      | The acceleration of the z-axis in m/s&#xB2; * 1000 |
 
 ### Magnetometer response (Packet ID: 0x0C)
 

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -180,9 +180,9 @@ see [3.1. Toggle bit field](#31-toggle---bit-field)
 
 | Field Name | Field Type | Notes                                              |
 |------------|------------|----------------------------------------------------|
-| X-axis     | int16      | The magnetic flux density of the x-axis in µT * 10 |
-| Y-axis     | int16      | The magnetic flux density of the y-axis in µT * 10 |
-| Z-axis     | int16      | The magnetic flux density of the z-axis in µT * 10 |
+| X-axis     | int16      | The magnetic flux density of the x-axis in &#xB5;T * 10 |
+| Y-axis     | int16      | The magnetic flux density of the y-axis in &#xB5;T * 10 |
+| Z-axis     | int16      | The magnetic flux density of the z-axis in &#xB5;T * 10 |
 
 ### Error message (Packet ID: 0x0D)
 

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -298,7 +298,7 @@ If there are multiple objects on the same position, all of them will be removed.
 | Distance   | uint16     | The distance to anchor 2 in centimetres |
 | Speed      | int8       | The speed of the wheels in m/s          |
 
-### BLE_CHAR_IMU (UUID:93758afa-ce6f-4670-9562-ce92bda84d49)
+### BLE_CHAR_IMU (UUID: 93758afa-ce6f-4670-9562-ce92bda84d49)
 
 | Field Name | Field Type | Notes                                                                                                                                   |
 |------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -289,14 +289,13 @@ If there are multiple objects on the same position, all of them will be removed.
 | Position X | int16      | The x coordinate in centimetres of anchor 2                 |
 | Position Y | int16      | The y coordinate in centimetres of anchor 2                 |
 
-### BLE_CHAR_ANCHORS_DISTANCES_WHEEL_SPEED (UUID: 254492a2-9324-469b-b1e2-4d4590972c35)
+### BLE_CHAR_ANCHORS_DISTANCES (UUID: 254492a2-9324-469b-b1e2-4d4590972c35)
 
 | Field Name | Field Type | Notes                                   |
 |------------|------------|-----------------------------------------|
 | Distance   | uint16     | The distance to anchor 0 in centimetres |
 | Distance   | uint16     | The distance to anchor 1 in centimetres |
 | Distance   | uint16     | The distance to anchor 2 in centimetres |
-| Speed      | int8       | The speed of the wheels in m/s          |
 
 ### BLE_CHAR_IMU (UUID: 93758afa-ce6f-4670-9562-ce92bda84d49)
 
@@ -306,6 +305,12 @@ If there are multiple objects on the same position, all of them will be removed.
 | x-Axis     | int16      | The value of the x-Axis                                                                                                                 |
 | y-Axis     | int16      | The value of the y-Axis                                                                                                                 |
 | z-Axis     | int16      | The value of the z-Axis                                                                                                                 |
+
+### BLE_CHAR_WHEEL_SPEED (UUID: 8efafa16-15de-461f-bde1-493261201e2b)
+
+| Field Name | Field Type | Notes                          |
+|------------|------------|--------------------------------|
+| Speed      | int8       | The speed of the wheels in m/s |
 
 ### BLE_CHAR_ERROR (UUID: dc458f08-ea3e-4fe1-adb3-25c840be081a)
 

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -176,8 +176,15 @@ see [3.1. Toggle bit field](#31-toggle---bit-field)
 | Y-axis     | float      | The acceleration of the y-axis in m/s² |
 | Z-axis     | float      | The acceleration of the z-axis in m/s² |
 
+### Magnetometer response (Packet ID: 0x0C)
 
-### Error message (Packet ID: 0x0C)
+| Field Name | Field Type | Notes                               |
+|------------|------------|-------------------------------------|
+| X-axis     | float      | The acceleration of the x-axis in T |
+| Y-axis     | float      | The acceleration of the y-axis in T |
+| Z-axis     | float      | The acceleration of the z-axis in T |
+
+### Error message (Packet ID: 0x0D)
 
 | Field Name     | Field Type         | Notes                                          |
 |----------------|--------------------|------------------------------------------------|
@@ -291,14 +298,14 @@ If there are multiple objects on the same position, all of them will be removed.
 | Distance   | uint16     | The distance to anchor 2 in centimetres |
 | Speed      | int8       | The speed of the wheels in m/s          |
 
-### BLE_CHAR_GYRO_ACCELEROMETER (UUID:93758afa-ce6f-4670-9562-ce92bda84d49)
+### BLE_CHAR_IMU (UUID:93758afa-ce6f-4670-9562-ce92bda84d49)
 
-| Field Name | Field Type | Notes                                                                                                |
-|------------|------------|------------------------------------------------------------------------------------------------------|
-| Type       | int8       | Indicates whether the packet is a gyroscope-package (value 0), or an accelerometer-package (value 1) |
-| x-Axis     | float      | The value of the x-Axis                                                                              |
-| y-Axis     | float      | The value of the y-Axis                                                                              |
-| z-Axis     | float      | The value of the z-Axis                                                                              |
+| Field Name | Field Type | Notes                                                                                                                                   |
+|------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| Type       | int8       | Indicates whether the packet is a gyroscope-package (value 0), an accelerometer-package (value 1), or an magnetometer-package (value 2) |
+| x-Axis     | float      | The value of the x-Axis                                                                                                                 |
+| y-Axis     | float      | The value of the y-Axis                                                                                                                 |
+| z-Axis     | float      | The value of the z-Axis                                                                                                                 |
 
 ### BLE_CHAR_ERROR (UUID: dc458f08-ea3e-4fe1-adb3-25c840be081a)
 
@@ -329,9 +336,9 @@ The 2nd byte changes certain logging options.
 
 ### 3.1.2. Bit field – 2. Byte (Logging)
 
-| Bit 7 (MSB) | Bit 6             | Bit 5           | Bit 4             | Bit 3            | Bit 2       | Bit 1         | Bit 0 (LSB) |
-|-------------|-------------------|-----------------|-------------------|------------------|-------------|---------------|-------------|
-| Positioning | Obstacle distance | Pathfinder path | Compass direction | Anchor distances | Wheel speed | Accelerometer | Gyroscope   |
+| Bit 7 (MSB) | Bit 6             | Bit 5           | Bit 4             | Bit 3            | Bit 2       | Bit 1                     | Bit 0 (LSB) |
+|-------------|-------------------|-----------------|-------------------|------------------|-------------|---------------------------|-------------|
+| Positioning | Obstacle distance | Pathfinder path | Compass direction | Anchor distances | Wheel speed | Inertial Measurement Unit | not used    |
 
 ## 3.2. Sensor – Packets (BLE only)
 

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -146,7 +146,38 @@ the Alphabot changes a setting by itself.
 
 see [3.1. Toggle bit field](#31-toggle---bit-field)
 
-### Error message (Packet ID: 0x08)
+### Anchor distance response (Packet ID: 0x08)
+
+| Field Name | Field Type | Notes                                   |
+|------------|------------|-----------------------------------------|
+| Distance   | uint16     | The distance to anchor 0 in centimeters |
+| Distance   | uint16     | The distance to anchor 1 in centimeters |
+| Distance   | uint16     | The distance to anchor 2 in centimeters |
+
+### Wheel speed response (Packet ID: 0x09)
+
+| Field Name | Field Type | Notes                          |
+|------------|------------|--------------------------------|
+| Speed      | int8       | The speed of the wheels in m/s |
+
+### Gyroscope response (Packet ID: 0x0A)
+
+| Field Name | Field Type | Notes                            |
+|------------|------------|----------------------------------|
+| X-axis     | float      | The speed of the x-axis in rad/s |
+| Y-axis     | float      | The speed of the y-axis in rad/s |
+| Z-axis     | float      | The speed of the z-axis in rad/s |
+
+### Accelerometer response (Packet ID: 0x0B)
+
+| Field Name | Field Type | Notes                                  |
+|------------|------------|----------------------------------------|
+| X-axis     | float      | The acceleration of the x-axis in m/s² |
+| Y-axis     | float      | The acceleration of the y-axis in m/s² |
+| Z-axis     | float      | The acceleration of the z-axis in m/s² |
+
+
+### Error message (Packet ID: 0x0C)
 
 | Field Name     | Field Type         | Notes                                          |
 |----------------|--------------------|------------------------------------------------|
@@ -250,6 +281,24 @@ If there are multiple objects on the same position, all of them will be removed.
 | Position Y | int16      | The y coordinate in centimetres of anchor 1                 |
 | Position X | int16      | The x coordinate in centimetres of anchor 2                 |
 | Position Y | int16      | The y coordinate in centimetres of anchor 2                 |
+
+### BLE_CHAR_ANCHORS_DISTANCES_WHEEL_SPEED (UUID: 254492a2-9324-469b-b1e2-4d4590972c35)
+
+| Field Name | Field Type | Notes                                   |
+|------------|------------|-----------------------------------------|
+| Distance   | uint16     | The distance to anchor 0 in centimetres |
+| Distance   | uint16     | The distance to anchor 1 in centimetres |
+| Distance   | uint16     | The distance to anchor 2 in centimetres |
+| Speed      | int8       | The speed of the wheels in m/s          |
+
+### BLE_CHAR_GYRO_ACCELEROMETER (UUID:93758afa-ce6f-4670-9562-ce92bda84d49)
+
+| Field Name | Field Type | Notes                                                                                                |
+|------------|------------|------------------------------------------------------------------------------------------------------|
+| Type       | int8       | Indicates whether the packet is a gyroscope-package (value 0), or an accelerometer-package (value 1) |
+| x-Axis     | float      | The value of the x-Axis                                                                              |
+| y-Axis     | float      | The value of the y-Axis                                                                              |
+| z-Axis     | float      | The value of the z-Axis                                                                              |
 
 ### BLE_CHAR_ERROR (UUID: dc458f08-ea3e-4fe1-adb3-25c840be081a)
 

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -170,16 +170,16 @@ see [3.1. Toggle bit field](#31-toggle---bit-field)
 
 ### Accelerometer response (Packet ID: 0x0B)
 
-| Field Name | Field Type | Notes                                         |
-|------------|------------|-----------------------------------------------|
+| Field Name | Field Type | Notes                                              |
+|------------|------------|----------------------------------------------------|
 | X-axis     | int16      | The acceleration of the x-axis in m/s&#xB2; * 1000 |
 | Y-axis     | int16      | The acceleration of the y-axis in m/s&#xB2; * 1000 |
 | Z-axis     | int16      | The acceleration of the z-axis in m/s&#xB2; * 1000 |
 
 ### Magnetometer response (Packet ID: 0x0C)
 
-| Field Name | Field Type | Notes                                              |
-|------------|------------|----------------------------------------------------|
+| Field Name | Field Type | Notes                                                   |
+|------------|------------|---------------------------------------------------------|
 | X-axis     | int16      | The magnetic flux density of the x-axis in &#xB5;T * 10 |
 | Y-axis     | int16      | The magnetic flux density of the y-axis in &#xB5;T * 10 |
 | Z-axis     | int16      | The magnetic flux density of the z-axis in &#xB5;T * 10 |


### PR DESCRIPTION
Closes #64 

Adds protocol documentation, code implementation and unit test cases for 5 new sensor responses:
- Wheel speed
- Anchor distances
- Accelerometer (IMU)
- Gyroscope (IMU)
- Magnetometer (IMU)