### PR TITLE
docs/protocol: Remove duplicate calibration request

### DIFF
--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Requests/ToggleRequest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Requests/ToggleRequest.cs
@@ -8,8 +8,6 @@ namespace AlphabotClientLibrary.Shared.Requests
     public class ToggleRequest : IAlphabotRequest
     {
         #region properties
-        public bool DoCompassCalibration { get; set; }
-
         public bool DoInvite { get; set; }
 
         public bool DoPositioningSystem { get; set; }
@@ -42,13 +40,12 @@ namespace AlphabotClientLibrary.Shared.Requests
             byte[] bytes = BitConverter.GetBytes(bitField);
             BitArray bitArray = new BitArray(bytes);
 
-            // Bits 0 and 1 are not used.
-            DoExploreMode = bitArray[2];
-            DoNavigationMode = bitArray[3];
-            DoCollisionAvoidance = bitArray[4];
-            DoPositioningSystem = bitArray[5];
-            DoInvite = bitArray[6];
-            DoCompassCalibration = bitArray[7];
+            // Bits 0 to 2 are not used.
+            DoExploreMode = bitArray[3];
+            DoNavigationMode = bitArray[4];
+            DoCollisionAvoidance = bitArray[5];
+            DoPositioningSystem = bitArray[6];
+            DoInvite = bitArray[7];
 
             LogGyroscope = bitArray[8];
             LogAccelerometer = bitArray[9];
@@ -81,13 +78,12 @@ namespace AlphabotClientLibrary.Shared.Requests
         {
             BitArray bitArray = new BitArray(16);
 
-            // Bits 0 and 1 are not used.
-            bitArray[2] = DoExploreMode;
-            bitArray[3] = DoNavigationMode;
-            bitArray[4] = DoCollisionAvoidance;
-            bitArray[5] = DoPositioningSystem;
-            bitArray[6] = DoInvite;
-            bitArray[7] = DoCompassCalibration;
+            // Bits 0 to 2 are not used.
+            bitArray[3] = DoExploreMode;
+            bitArray[4] = DoNavigationMode;
+            bitArray[5] = DoCollisionAvoidance;
+            bitArray[6] = DoPositioningSystem;
+            bitArray[7] = DoInvite;
 
             bitArray[8] = LogGyroscope;
             bitArray[9] = LogAccelerometer;

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/ToggleResponse.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Shared/Responses/ToggleResponse.cs
@@ -7,8 +7,6 @@ namespace AlphabotClientLibrary.Shared.Responses
     public class ToggleResponse : IAlphabotResponse
     {
         #region properties
-        public bool DoCompassCalibration { get; private set; }
-
         public bool DoInvite { get; private set; }
 
         public bool DoPositioningSystem { get; private set; }
@@ -51,13 +49,12 @@ namespace AlphabotClientLibrary.Shared.Responses
         {
             BitArray bitArray = new BitArray(bytes);
 
-            //bit 0 and 1 are not used
-            DoExploreMode = bitArray[2];
-            DoNavigationMode = bitArray[3];
-            DoCollisionAvoidance = bitArray[4];
-            DoPositioningSystem = bitArray[5];
-            DoInvite = bitArray[6];
-            DoCompassCalibration = bitArray[7];
+            // Bits 0 to 2 are not used.
+            DoExploreMode = bitArray[3];
+            DoNavigationMode = bitArray[4];
+            DoCollisionAvoidance = bitArray[5];
+            DoPositioningSystem = bitArray[6];
+            DoInvite = bitArray[7];
 
             LogGyroscope = bitArray[8];
             LogAccelerometer = bitArray[9];

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpRequestTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpRequestTest.cs
@@ -114,7 +114,7 @@ namespace AlphabotClientLibrary.Test
             request.LogPositioning = true;
             request.LogGyroscope = true;
 
-            byte[] expectedBytes = { 0x05, 0x04, 0x81 };
+            byte[] expectedBytes = { 0x05, 0x08, 0x81 };
 
             Assert.Equal(expectedBytes, request.GetBytes());
         }

--- a/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
+++ b/clients/AlphabotClientLibrary/AlphabotClientLibrary.Test/TcpResponseTest.cs
@@ -140,13 +140,12 @@ namespace AlphabotClientLibrary.Test
         [Fact]
         public void TestToggleResponse()
         {
-            byte[] bytes = { 0x07, 0xE0, 0x30 };
+            byte[] bytes = { 0x07, 0xC0, 0x30 };
 
             IAlphabotResponse response = new TcpResponseInterpreter(bytes).GetResponse();
             Assert.True(response is ToggleResponse, "Response was of the wrong type");
 
             ToggleResponse toggleResponse = response as ToggleResponse;
-            Assert.True(toggleResponse.DoCompassCalibration);
             Assert.True(toggleResponse.DoInvite);
             Assert.True(toggleResponse.DoPositioningSystem);
             Assert.True(toggleResponse.LogPathfinderPath);

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -274,9 +274,9 @@ The 2nd byte changes certain logging options.
 
 ### 3.1.1. Bit field – 1. Byte (Settings)
 
-| Bit 7 (MSB)         | Bit 6  | Bit 5       | Bit 4               | Bit 3           | Bit 2        | Bit 1    | Bit 0 (LSB) |
-|---------------------|--------|-------------|---------------------|-----------------|--------------|----------|-------------|
-| Compass calibration | Invite | Positioning | Collision Avoidance | Navigation-Mode | Explore-Mode | not used | not used    |
+| Bit 7 (MSB) | Bit 6  | Bit 5       | Bit 4               | Bit 3           | Bit 2        | Bit 1    | Bit 0 (LSB) |
+|-------------|--------|-------------|---------------------|-----------------|--------------|----------|-------------|
+| not used    | Invite | Positioning | Collision Avoidance | Navigation-Mode | Explore-Mode | not used | not used    |
 
 ### 3.1.2. Bit field – 2. Byte (Logging)
 

--- a/docs/wifi_ble_communication_protocol.md
+++ b/docs/wifi_ble_communication_protocol.md
@@ -274,9 +274,9 @@ The 2nd byte changes certain logging options.
 
 ### 3.1.1. Bit field – 1. Byte (Settings)
 
-| Bit 7 (MSB) | Bit 6  | Bit 5       | Bit 4               | Bit 3           | Bit 2        | Bit 1    | Bit 0 (LSB) |
-|-------------|--------|-------------|---------------------|-----------------|--------------|----------|-------------|
-| not used    | Invite | Positioning | Collision Avoidance | Navigation-Mode | Explore-Mode | not used | not used    |
+| Bit 7 (MSB) | Bit 6       | Bit 5               | Bit 4           | Bit 3        | Bit 2    | Bit 1    | Bit 0 (LSB) |
+|-------------|-------------|---------------------|-----------------|--------------|----------|----------|-------------|
+| Invite      | Positioning | Collision Avoidance | Navigation-Mode | Explore-Mode | not used | not used | not used    |
 
 ### 3.1.2. Bit field – 2. Byte (Logging)
 


### PR DESCRIPTION
Remove the compass calibration setting from the settings bit field,
as the compass can already be calibrated in another way.