### PR TITLE
emulator_rpi: Fix wrong GPIO memory offset

### DIFF
--- a/emulator_rpi.py
+++ b/emulator_rpi.py
@@ -77,7 +77,7 @@ def handle_socket_communication():
 def hcsr04_front_pinEchoHandler(state):
     print("Front Echo State: " + str(state))
     if is_connected:
-        m = 0x3f200000 + int(HCSR04_ECHO / 32)
+        m = 0x3f200000 + int(HCSR04_ECHO / 32) * 4
         if state:
             m += 0x1c
         else:


### PR DESCRIPTION
Fix wrong GPIO memory offset when accessing a GPIO pin above 31.