### PR TITLE
esp32/PrimaryESP: Fix wrong position data

### DIFF
--- a/esp32/PrimaryESP32/alphabot/alphabot.ino
+++ b/esp32/PrimaryESP32/alphabot/alphabot.ino
@@ -436,9 +436,9 @@ void loop() {
 
         if (logging.positioning) {
             sensor_logging_val[sensor_logging_val_len] = (uint8_t)lps_x;
-            sensor_logging_val[sensor_logging_val_len + 1] = (((uint16_t)lps_x >> 8) & 0x07) | ((lps_x < 0) << 3);
+            sensor_logging_val[sensor_logging_val_len + 1] = (((uint16_t)lps_x >> 8) & 0x07) | ((lps_x <= -1.0) << 3);
             sensor_logging_val[sensor_logging_val_len + 1] |= (uint8_t)lps_y << 4;
-            sensor_logging_val[sensor_logging_val_len + 2] = (((uint16_t)lps_y >> 4) & 0x7F) | ((lps_y < 0) << 7);
+            sensor_logging_val[sensor_logging_val_len + 2] = (((uint16_t)lps_y >> 4) & 0x7F) | ((lps_y <= -1.0) << 7);
             sensor_logging_val_len += 3;
             sensor_logging_val[sensor_logging_counter / 4] |= 2 << ((sensor_logging_counter % 4) * 2);
             sensor_logging_counter++;


### PR DESCRIPTION
Fix mistakenly transmiting -2048 when the value of an axis is between 0 and -1.