### PR TITLE
esp32/PrimaryESP: Increase I2C speed to 400 kbps

### DIFF
--- a/esp32/PrimaryESP32/alphabot/alphabot.ino
+++ b/esp32/PrimaryESP32/alphabot/alphabot.ino
@@ -278,7 +278,7 @@ void setup() {
     stepper_motor->calibrate();
     two_motor_drive = new TwoMotorDrive(motor_left, motor_right, stepper_motor);
     driving_assistent = new DrivingAssistent();
-    Wire.begin(I2C_SDA, I2C_SCL, (uint32_t)100000);
+    Wire.begin(I2C_SDA, I2C_SCL, (uint32_t)400000);
     distance_meter = new DistanceMeter(5);
     ble_handler = new BLEHandler(&charUpdateMotorsDataReceived,
                                  &charToggleDataReceived,


### PR DESCRIPTION
By increasing the I2C speed, the ESP32 has to wait less to read data
from I2C devices. This in turn leaves more time for other operations.