### PR TITLE
esp32/PrimaryESP: Increase max ICM20948 I2C transfer size

### DIFF
--- a/esp32/PrimaryESP32/lib/ICM20948/src/Icm20948Transport.h
+++ b/esp32/PrimaryESP32/lib/ICM20948/src/Icm20948Transport.h
@@ -41,9 +41,9 @@ extern "C" {
 struct inv_icm20948;
 
 /** @brief Max size that can be read across I2C or SPI data lines */
-#define INV_MAX_SERIAL_READ 16
+#define INV_MAX_SERIAL_READ 32
 /** @brief Max size that can be written across I2C or SPI data lines */
-#define INV_MAX_SERIAL_WRITE 16
+#define INV_MAX_SERIAL_WRITE 32
 
 void INV_EXPORT inv_icm20948_transport_init(struct inv_icm20948 * s);
 


### PR DESCRIPTION
Increase the maximum read/write size that is used for I2C communication
with the ICM-20948 chip. This makes the read/write processes a bit
faster.