### PR TITLE
esp32/PrimaryESP32: Disable unused Serial2 TX pin

### DIFF
--- a/esp32/PrimaryESP32/alphabot/PositioningSystem.cpp
+++ b/esp32/PrimaryESP32/alphabot/PositioningSystem.cpp
@@ -176,5 +176,5 @@ PositioningSystem::PositioningSystem(uint16_t anc1_short_address, uint16_t anc2_
     last_anc_ranges[1] = 0;
     last_anc_ranges[2] = 0;
 
-    Serial2.begin(115200, SERIAL_8N1, SERIAL2_RX, SERIAL2_TX);
+    Serial2.begin(115200, SERIAL_8N1, SERIAL2_RX, -1);
 }

--- a/esp32/PrimaryESP32/alphabot/pinconfig.h
+++ b/esp32/PrimaryESP32/alphabot/pinconfig.h
@@ -21,7 +21,6 @@
 #define I2C_SCL 22
 
 #define SERIAL2_RX 16
-#define SERIAL2_TX 17
 
 #define LEFT_WHEEL_ENCODER_D0 35
 #define RIGHT_WHEEL_ENCODER_D0 34


### PR DESCRIPTION
Disable the unused TX pin of the serial communication with the
positioning module.