### PR TITLE
esp32/PrimaryESP: Specify platform version in platformio.ini

### DIFF
--- a/esp32/PrimaryESP32/platformio.ini
+++ b/esp32/PrimaryESP32/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = alphabot
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@4.0.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200


### PR DESCRIPTION
Specify the platform version in platformio.ini to prevent bugs caused
by breaking changes from future versions.