### PR TITLE
clients/android: Fix a concurrency issue

### DIFF
--- a/clients/AlphabotAndroidClient/app/src/main/java/at/mg6/filip/alphabotandroidclient/ControlActivity.java
+++ b/clients/AlphabotAndroidClient/app/src/main/java/at/mg6/filip/alphabotandroidclient/ControlActivity.java
@@ -465,8 +465,10 @@ public class ControlActivity extends ImmersiveActivity implements SensorEventLis
 
                     if (obstacle == null) {
                         if (pendingObstacleToAdd != null) {
-                            pendingObstacleToAdd.setId(id);
+                            lpsView.removeObstacle(pendingObstacleToAdd);
                             pendingObstacleToAdd = null;
+                            obstacle = new Obstacle(x, y, width, height, id);
+                            lpsView.addObstacle(obstacle);
 
                             runOnUiThread(new Runnable() {
                                 @Override


### PR DESCRIPTION
Fix a bug that can cause an obstacle to have incorrect coordinates and
dimensions. This can happen while an obstacle is pending and another
obstacle is received. The client mistakes the newly received obstacle
for the pending one and assigns the wrong id to the pending obstacle.

The solution is to remove the pending obstacle and add the newly
received obstacle to the list of obstacles. There is still the problem
of removing the pending obstacle by mistake, but that is better than
having a misplaced obstacle.